### PR TITLE
BugFix - customMessage was not being properly appended to the commit message.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 
 group 'at.karriere.gradle.plugins'
-version '1.3.1'
+version '1.3.2'
 
 task wrapper(type: Wrapper) {
   gradleVersion = '4.9'

--- a/src/main/groovy/at/karriere/gradle/plugins/VersionPlugin.groovy
+++ b/src/main/groovy/at/karriere/gradle/plugins/VersionPlugin.groovy
@@ -23,7 +23,7 @@ class VersionPlugin implements Plugin<Project> {
                 project.tasks['classes'].dependsOn project.setVersion
             }
 
-            project.tasks['increaseVersion'].customMessage = project.extensions.versionPlugin.customMessage
+            project.tasks['increaseVersion'].customMessage = project.extensions.versionPlugin.customMessage ?: ''
         }
     }
 

--- a/src/main/groovy/at/karriere/gradle/plugins/VersionPlugin.groovy
+++ b/src/main/groovy/at/karriere/gradle/plugins/VersionPlugin.groovy
@@ -16,13 +16,14 @@ class VersionPlugin implements Plugin<Project> {
         }
 
         project.task('increaseVersion', type: IncreaseVersionTask) {
-            customMessage = project.extensions.versionPlugin.customMessage
         }
 
         project.afterEvaluate {
             if (project.tasks.hasProperty('classes')) {
                 project.tasks['classes'].dependsOn project.setVersion
             }
+
+            project.tasks['increaseVersion'].customMessage = project.extensions.versionPlugin.customMessage
         }
     }
 

--- a/src/main/groovy/at/karriere/gradle/plugins/task/IncreaseVersionTask.groovy
+++ b/src/main/groovy/at/karriere/gradle/plugins/task/IncreaseVersionTask.groovy
@@ -55,4 +55,8 @@ class IncreaseVersionTask extends BaseVersionTask {
         }
         version.snapshotVersion = null
     }
+
+    void setCustomMessage(String customMessage) {
+        this.customMessage = customMessage
+    }
 }


### PR DESCRIPTION
Previous attempt was a good start, but didn't quite work as expected.  

I learned a bit more about testing these plugins and put together a test project to actually verify that the `customMessage` is being appended properly.  (Also verified that a blank config of `versionPlugin` would still function as desired.)

Bumped version to 1.3.2